### PR TITLE
Bad format in ServiceManifest. Fail deploy to SFC.

### DIFF
--- a/generators/guestcontainer/templates/Service/ServiceManifest.xml
+++ b/generators/guestcontainer/templates/Service/ServiceManifest.xml
@@ -15,6 +15,6 @@
          </ContainerHost>
       </EntryPoint>
       <EnvironmentVariables> 
-      </EnvironmentVariables> 
+      </EnvironmentVariables> 
    </CodePackage>
  </ServiceManifest>

--- a/generators/guestcontainer/templates/Service/ServiceManifestWithPorts.xml
+++ b/generators/guestcontainer/templates/Service/ServiceManifestWithPorts.xml
@@ -15,7 +15,7 @@
          </ContainerHost>
       </EntryPoint>
       <EnvironmentVariables> 
-      </EnvironmentVariables> 
+      </EnvironmentVariables> 
    </CodePackage>
    <Resources>
         <Endpoints>


### PR DESCRIPTION
### Bad format in ServiceManifest. Fail deploy to SFC.

**Test-ServiceFabricApplicationPackage:** 
_Exception while parsing XML file: C:\Users\AppData\Local\Temp\Te
stApplicationPackage_128168357458\l32x45wc.4un\TestApp\TestServicePkg\ServiceManifest.xml. Check if XML content is
well formed by comparing against the service model schema (ServiceFabricServiceModel.xsd) which is shipped with the
SDK. By default, the schema file is installed to 'C:\Program Files\Microsoft SDKs\Service
Fabric\schemas\ServiceFabricServiceModel.xsd'._
**FileName:**
_C:\Users\\AppData\Local\Temp\TestApplicationPackage_128168357458\l32x45wc.4un\TestApp\TestServ
icePkg\ServiceManifest.xml_